### PR TITLE
refactor: update module path with github

### DIFF
--- a/cmd/fil_cmd.go
+++ b/cmd/fil_cmd.go
@@ -3,8 +3,9 @@ package cmd
 import (
 	"context"
 	"fmt"
-	"wrappedeal/internal/filecoin"
-	"wrappedeal/internal/utils"
+
+	"github.com/eastore-project/fil-deal-wrapper/internal/filecoin"
+	"github.com/eastore-project/fil-deal-wrapper/internal/utils"
 
 	"github.com/urfave/cli/v2"
 )

--- a/cmd/read_contract_cmd.go
+++ b/cmd/read_contract_cmd.go
@@ -4,8 +4,9 @@ import (
 	"context"
 	"fmt"
 	"strconv"
-	"wrappedeal/internal/contract"
-	"wrappedeal/internal/eth"
+
+	"github.com/eastore-project/fil-deal-wrapper/internal/contract"
+	"github.com/eastore-project/fil-deal-wrapper/internal/eth"
 
 	"github.com/urfave/cli/v2"
 )

--- a/cmd/write_contract_cmd.go
+++ b/cmd/write_contract_cmd.go
@@ -4,9 +4,10 @@ import (
 	"context"
 	"fmt"
 	"strconv"
-	"wrappedeal/internal/contract"
-	"wrappedeal/internal/eth"
-	"wrappedeal/internal/utils"
+
+	"github.com/eastore-project/fil-deal-wrapper/internal/contract"
+	"github.com/eastore-project/fil-deal-wrapper/internal/eth"
+	"github.com/eastore-project/fil-deal-wrapper/internal/utils"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/urfave/cli/v2"

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module wrappedeal
+module github.com/eastore-project/fil-deal-wrapper
 
 go 1.22.7
 

--- a/internal/contract/add_erc20_funds.go
+++ b/internal/contract/add_erc20_funds.go
@@ -5,9 +5,9 @@ import (
 	"fmt"
 	"math/big"
 
-	"wrappedeal/internal/eth"
-	"wrappedeal/internal/types"
-	"wrappedeal/internal/utils"
+	"github.com/eastore-project/fil-deal-wrapper/internal/eth"
+	"github.com/eastore-project/fil-deal-wrapper/internal/types"
+	"github.com/eastore-project/fil-deal-wrapper/internal/utils"
 
 	"github.com/ethereum/go-ethereum/common"
 	ethTypes "github.com/ethereum/go-ethereum/core/types"

--- a/internal/contract/add_funds.go
+++ b/internal/contract/add_funds.go
@@ -5,9 +5,9 @@ import (
 	"fmt"
 	"math/big"
 
-	"wrappedeal/internal/eth"
-	"wrappedeal/internal/types"
-	"wrappedeal/internal/utils"
+	"github.com/eastore-project/fil-deal-wrapper/internal/eth"
+	"github.com/eastore-project/fil-deal-wrapper/internal/types"
+	"github.com/eastore-project/fil-deal-wrapper/internal/utils"
 
 	ethTypes "github.com/ethereum/go-ethereum/core/types"
 )

--- a/internal/contract/add_storage_provider.go
+++ b/internal/contract/add_storage_provider.go
@@ -4,9 +4,9 @@ import (
 	"context"
 	"fmt"
 
-	"wrappedeal/internal/eth"
-	"wrappedeal/internal/types"
-	"wrappedeal/internal/utils"
+	"github.com/eastore-project/fil-deal-wrapper/internal/eth"
+	"github.com/eastore-project/fil-deal-wrapper/internal/types"
+	"github.com/eastore-project/fil-deal-wrapper/internal/utils"
 
 	"math/big"
 

--- a/internal/contract/add_to_whitelist.go
+++ b/internal/contract/add_to_whitelist.go
@@ -4,9 +4,9 @@ import (
 	"context"
 	"fmt"
 
-	"wrappedeal/internal/eth"
-	"wrappedeal/internal/types"
-	"wrappedeal/internal/utils"
+	"github.com/eastore-project/fil-deal-wrapper/internal/eth"
+	"github.com/eastore-project/fil-deal-wrapper/internal/types"
+	"github.com/eastore-project/fil-deal-wrapper/internal/utils"
 
 	ethTypes "github.com/ethereum/go-ethereum/core/types"
 )

--- a/internal/contract/approve_erc20.go
+++ b/internal/contract/approve_erc20.go
@@ -5,9 +5,9 @@ import (
 	"fmt"
 	"math/big"
 
-	"wrappedeal/internal/eth"
-	"wrappedeal/internal/types"
-	"wrappedeal/internal/utils"
+	"github.com/eastore-project/fil-deal-wrapper/internal/eth"
+	"github.com/eastore-project/fil-deal-wrapper/internal/types"
+	"github.com/eastore-project/fil-deal-wrapper/internal/utils"
 
 	"strings"
 

--- a/internal/contract/get_deals_from_miner_id.go
+++ b/internal/contract/get_deals_from_miner_id.go
@@ -3,7 +3,8 @@ package contract
 import (
 	"context"
 	"fmt"
-	"wrappedeal/internal/types"
+
+	"github.com/eastore-project/fil-deal-wrapper/internal/types"
 
 	"github.com/ethereum/go-ethereum"
 )

--- a/internal/contract/get_sp_from_id.go
+++ b/internal/contract/get_sp_from_id.go
@@ -5,7 +5,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"math/big"
-	"wrappedeal/internal/types"
+
+	"github.com/eastore-project/fil-deal-wrapper/internal/types"
 
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common"

--- a/internal/contract/get_sp_funds_for_deal.go
+++ b/internal/contract/get_sp_funds_for_deal.go
@@ -3,7 +3,8 @@ package contract
 import (
 	"context"
 	"fmt"
-	"wrappedeal/internal/types"
+
+	"github.com/eastore-project/fil-deal-wrapper/internal/types"
 
 	"math/big"
 

--- a/internal/contract/get_token_funds_for_sp.go
+++ b/internal/contract/get_token_funds_for_sp.go
@@ -5,7 +5,8 @@ import (
 	"fmt"
 
 	"math/big"
-	"wrappedeal/internal/types"
+
+	"github.com/eastore-project/fil-deal-wrapper/internal/types"
 
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common"

--- a/internal/contract/is_whitelisted.go
+++ b/internal/contract/is_whitelisted.go
@@ -3,7 +3,8 @@ package contract
 import (
 	"context"
 	"fmt"
-	"wrappedeal/internal/types"
+
+	"github.com/eastore-project/fil-deal-wrapper/internal/types"
 
 	"github.com/ethereum/go-ethereum"
 )

--- a/internal/contract/remove_from_whitelist.go
+++ b/internal/contract/remove_from_whitelist.go
@@ -4,9 +4,9 @@ import (
 	"context"
 	"fmt"
 
-	"wrappedeal/internal/eth"
-	"wrappedeal/internal/types"
-	"wrappedeal/internal/utils"
+	"github.com/eastore-project/fil-deal-wrapper/internal/eth"
+	"github.com/eastore-project/fil-deal-wrapper/internal/types"
+	"github.com/eastore-project/fil-deal-wrapper/internal/utils"
 
 	ethTypes "github.com/ethereum/go-ethereum/core/types"
 )

--- a/internal/contract/update_storage_provider.go
+++ b/internal/contract/update_storage_provider.go
@@ -4,9 +4,9 @@ import (
 	"context"
 	"fmt"
 
-	"wrappedeal/internal/eth"
-	"wrappedeal/internal/types"
-	"wrappedeal/internal/utils"
+	"github.com/eastore-project/fil-deal-wrapper/internal/eth"
+	"github.com/eastore-project/fil-deal-wrapper/internal/types"
+	"github.com/eastore-project/fil-deal-wrapper/internal/utils"
 
 	"math/big"
 

--- a/internal/contract/withdraw_erc20_funds.go
+++ b/internal/contract/withdraw_erc20_funds.go
@@ -5,9 +5,9 @@ import (
 	"fmt"
 	"math/big"
 
-	"wrappedeal/internal/eth"
-	"wrappedeal/internal/types"
-	"wrappedeal/internal/utils"
+	"github.com/eastore-project/fil-deal-wrapper/internal/eth"
+	"github.com/eastore-project/fil-deal-wrapper/internal/types"
+	"github.com/eastore-project/fil-deal-wrapper/internal/utils"
 
 	"github.com/ethereum/go-ethereum/common"
 	ethTypes "github.com/ethereum/go-ethereum/core/types"

--- a/internal/contract/withdraw_funds.go
+++ b/internal/contract/withdraw_funds.go
@@ -5,9 +5,9 @@ import (
 	"fmt"
 	"math/big"
 
-	"wrappedeal/internal/eth"
-	"wrappedeal/internal/types"
-	"wrappedeal/internal/utils"
+	"github.com/eastore-project/fil-deal-wrapper/internal/eth"
+	"github.com/eastore-project/fil-deal-wrapper/internal/types"
+	"github.com/eastore-project/fil-deal-wrapper/internal/utils"
 
 	ethTypes "github.com/ethereum/go-ethereum/core/types"
 )

--- a/internal/contract/withdraw_sp_fund_by_token.go
+++ b/internal/contract/withdraw_sp_fund_by_token.go
@@ -4,9 +4,9 @@ import (
 	"context"
 	"fmt"
 
-	"wrappedeal/internal/eth"
-	"wrappedeal/internal/types"
-	"wrappedeal/internal/utils"
+	"github.com/eastore-project/fil-deal-wrapper/internal/eth"
+	"github.com/eastore-project/fil-deal-wrapper/internal/types"
+	"github.com/eastore-project/fil-deal-wrapper/internal/utils"
 
 	"github.com/ethereum/go-ethereum/common"
 	ethTypes "github.com/ethereum/go-ethereum/core/types"

--- a/internal/contract/withdraw_sp_funds_for_deal.go
+++ b/internal/contract/withdraw_sp_funds_for_deal.go
@@ -4,9 +4,9 @@ import (
 	"context"
 	"fmt"
 
-	"wrappedeal/internal/eth"
-	"wrappedeal/internal/types"
-	"wrappedeal/internal/utils"
+	"github.com/eastore-project/fil-deal-wrapper/internal/eth"
+	"github.com/eastore-project/fil-deal-wrapper/internal/types"
+	"github.com/eastore-project/fil-deal-wrapper/internal/utils"
 
 	ethTypes "github.com/ethereum/go-ethereum/core/types"
 )

--- a/internal/contract/withdraw_sp_funds_for_terminated_deal.go
+++ b/internal/contract/withdraw_sp_funds_for_terminated_deal.go
@@ -4,9 +4,9 @@ import (
 	"context"
 	"fmt"
 
-	"wrappedeal/internal/eth"
-	"wrappedeal/internal/types"
-	"wrappedeal/internal/utils"
+	"github.com/eastore-project/fil-deal-wrapper/internal/eth"
+	"github.com/eastore-project/fil-deal-wrapper/internal/types"
+	"github.com/eastore-project/fil-deal-wrapper/internal/utils"
 
 	ethTypes "github.com/ethereum/go-ethereum/core/types"
 )

--- a/internal/eth/client.go
+++ b/internal/eth/client.go
@@ -11,8 +11,9 @@ import (
 	"math/big"
 	"os"
 	"path/filepath"
-	"wrappedeal/internal/types"
-	"wrappedeal/internal/utils"
+
+	"github.com/eastore-project/fil-deal-wrapper/internal/types"
+	"github.com/eastore-project/fil-deal-wrapper/internal/utils"
 
 	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/common"

--- a/internal/eth/transactions.go
+++ b/internal/eth/transactions.go
@@ -4,7 +4,8 @@ import (
 	"context"
 	"fmt"
 	"time"
-	"wrappedeal/internal/types"
+
+	"github.com/eastore-project/fil-deal-wrapper/internal/types"
 
 	"github.com/ethereum/go-ethereum/common"
 	ethTypes "github.com/ethereum/go-ethereum/core/types"

--- a/internal/filecoin/deal.go
+++ b/internal/filecoin/deal.go
@@ -6,7 +6,8 @@ import (
 	"errors"
 	"fmt"
 	"strings"
-	"wrappedeal/internal/utils"
+
+	"github.com/eastore-project/fil-deal-wrapper/internal/utils"
 
 	"github.com/ethereum/go-ethereum/common"
 	clinode "github.com/filecoin-project/boost/cli/node"

--- a/internal/filecoin/get_actor_id.go
+++ b/internal/filecoin/get_actor_id.go
@@ -4,7 +4,8 @@ import (
 	"context"
 	"fmt"
 	"log"
-	"wrappedeal/internal/utils"
+
+	"github.com/eastore-project/fil-deal-wrapper/internal/utils"
 
 	"github.com/filecoin-project/boost/cli/node"
 	chain_types "github.com/filecoin-project/lotus/chain/types"

--- a/internal/filecoin/local_deal.go
+++ b/internal/filecoin/local_deal.go
@@ -6,7 +6,7 @@ import (
 	"os"
 	"path/filepath"
 
-	"wrappedeal/internal/utils"
+	"github.com/eastore-project/fil-deal-wrapper/internal/utils"
 
 	lcli "github.com/filecoin-project/lotus/cli"
 	"github.com/urfave/cli/v2"

--- a/internal/utils/generateCar.go
+++ b/internal/utils/generateCar.go
@@ -9,7 +9,8 @@ import (
 	"os"
 	"path"
 	"path/filepath"
-	"wrappedeal/internal/types"
+
+	"github.com/eastore-project/fil-deal-wrapper/internal/types"
 
 	commcid "github.com/filecoin-project/go-fil-commcid"
 	commp "github.com/filecoin-project/go-fil-commp-hashhash"

--- a/main.go
+++ b/main.go
@@ -3,7 +3,8 @@ package main
 import (
 	"log"
 	"os"
-	"wrappedeal/cmd"
+
+	"github.com/eastore-project/fil-deal-wrapper/cmd"
 
 	"github.com/urfave/cli/v2"
 )


### PR DESCRIPTION
This pull request includes changes to update the module path and import paths throughout the project. The changes are primarily focused on replacing the old module path `wrappedeal` with the new module path `github.com/eastore-project/fil-deal-wrapper`.

### Module Path Update:

* [`go.mod`](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6L1-R1): Changed the module path from `wrappedeal` to `github.com/eastore-project/fil-deal-wrapper`.
- Import path update throughout the project